### PR TITLE
fix: URL encode file paths with special characters in File Structure

### DIFF
--- a/src/components/overview/ArchitectureDiagram.tsx
+++ b/src/components/overview/ArchitectureDiagram.tsx
@@ -354,8 +354,12 @@ export function ArchitectureDiagram({
           if (fileIssueMap[data.path]) {
             setSelectedFile(data.path);
           } else {
+            const encodedPath = data.path
+              .split("/")
+              .map(encodeURIComponent)
+              .join("/");
             window.open(
-              `https://github.com/${owner}/${repo}/blob/main/${data.path}`,
+              `https://github.com/${owner}/${repo}/blob/main/${encodedPath}`,
               "_blank"
             );
           }
@@ -367,8 +371,12 @@ export function ArchitectureDiagram({
         if (fileIssueMap[d.data.path]) {
           setSelectedFile(d.data.path);
         } else {
+          const encodedPath = d.data.path
+            .split("/")
+            .map(encodeURIComponent)
+            .join("/");
           window.open(
-            `https://github.com/${owner}/${repo}/blob/main/${d.data.path}`,
+            `https://github.com/${owner}/${repo}/blob/main/${encodedPath}`,
             "_blank"
           );
         }


### PR DESCRIPTION
Clicking on files under Next.js dynamic routes (e.g., [owner] folders) redirected to invalid GitHub URLs because brackets weren't being encoded.

## Solution
Encode each path segment using encodeURIComponent before constructing the GitHub URL.

### Before:

https://github.com/user/repo/blob/main/src/app/activity/[owner]/[repo]/page.tsx -> 404 error page

### After:

https://github.com/ElshadHu/repo-health/blob/main/src/app/activity/%5Bowner%5D/%5Brepo%5D/page.tsx -> Source file

## Changes

Updated both click handlers (rect and text elements) in [`ArchitectureDiagram.tsx`](https://github.com/ElshadHu/repo-health/blob/main/src/components/overview/ArchitectureDiagram.tsx) to properly encode file paths

Fix #20 